### PR TITLE
Zyres 0.0.4 Adjustments

### DIFF
--- a/css/staticHeader.css
+++ b/css/staticHeader.css
@@ -98,6 +98,10 @@ header + div:not(.bmg-header_spacer) {
     z-index: 50;
 }
 
+.arrow-icon {
+    color: rgba(255, 255, 255, 0.5);
+}
+
 .left-menu {
     align-items: center;
     display: flex;

--- a/css/staticHeader.css
+++ b/css/staticHeader.css
@@ -484,6 +484,7 @@ li > a.language-item-button {
     z-index: 1;
 }
 
+.search-block .search-icon,
 .search-block .search-icon svg {
     fill: #666666;
     transition: all 700ms ease-out;
@@ -509,6 +510,7 @@ li > a.language-item-button {
     border-color: #FFFFFF !important;
 }
 
+.search-block input:focus ~ .search-icon,
 .search-block input:focus ~ .search-icon svg {
     fill: #FFFFFF;
 }

--- a/shop.html
+++ b/shop.html
@@ -32,9 +32,11 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-1"/>
                                     <label class="menu-item" for="menu-item-toggle-1">
                                         <div class="title">Menu 1</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
@@ -150,16 +152,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-3"/>
                                     <label class="menu-item" for="menu-item-toggle-3">
                                         <div class="title">Menu 3</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-3">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -194,16 +200,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-4"/>
                                     <label class="menu-item" for="menu-item-toggle-4">
                                         <div class="title">Menu 4</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-4">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -238,16 +248,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-5"/>
                                     <label class="menu-item" for="menu-item-toggle-5">
                                         <div class="title">Menu 5</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-5">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -312,16 +326,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-6"/>
                                     <label class="menu-item" for="menu-item-toggle-6">
                                         <div class="title">Menu 6</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-6">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -356,16 +374,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-7"/>
                                     <label class="menu-item" for="menu-item-toggle-7">
                                         <div class="title">Menu 7</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-7">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -400,16 +422,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-8"/>
                                     <label class="menu-item" for="menu-item-toggle-8">
                                         <div class="title">Menu 8</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-8">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -444,16 +470,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-9"/>
                                     <label class="menu-item" for="menu-item-toggle-9">
                                         <div class="title">Menu 9</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-9">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -518,16 +548,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-10"/>
                                     <label class="menu-item" for="menu-item-toggle-10">
                                         <div class="title">Menu 10</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-10">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -562,16 +596,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-11"/>
                                     <label class="menu-item" for="menu-item-toggle-11">
                                         <div class="title">Menu 11</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-11">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -606,16 +644,20 @@
                                     <input class="menu-item-toggle" type="checkbox" id="menu-item-toggle-12"/>
                                     <label class="menu-item" for="menu-item-toggle-12">
                                         <div class="title">Menu 12</div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
-                                            <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
+                                        <span class="arrow-icon">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="8" height="14" viewBox="0 0 8 14" fill="none">
+                                                <path d="M1 13L7 7L1 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                                            </svg>
+                                        </span>
                                     </label>
                                     <div class="submenu">
                                         <div class="submenu-header">
                                             <label class="back-link" for="menu-item-toggle-12">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
-                                                    <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                                                </svg>
+                                                <span class="arrow-icon">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="11" viewBox="0 0 6 11" fill="none">
+                                                        <path d="M5 1.5L1 5.5L5 9.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                                    </svg>
+                                                </span>
 
                                                 zurück
                                             </label>
@@ -650,9 +692,11 @@
                         </div>
                         <div class="menu-box-footer">
                             <a class="home-button" target="_blank" href="https://borussia.de">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="6" height="9" viewBox="0 0 6 9" fill="none">
-                                    <path d="M5 0.5L1 4.5L5 8.5" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-                                </svg>
+                                <span class="arrow-icon">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="9" viewBox="0 0 6 9" fill="none">
+                                        <path d="M5 0.5L1 4.5L5 8.5" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+                                    </svg>
+                                </span>
 
                                 borussia.de
                             </a>
@@ -660,7 +704,7 @@
                                 <input type="checkbox" class="language-switch-toggle" id="language-switch-toggle" hidden/>
                                 <label for="language-switch-toggle" type="button">
                                     DE
-                                    <span class="language-arrow">
+                                    <span class="language-arrow arrow-icon">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="8" viewBox="0 0 15 8" fill="none">
                                             <path d="M1.82727 1L7.66364 7L13.5 1" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         </svg>


### PR DESCRIPTION
Die Color Styles werden bei unseren Systemen nicht direkt auf die SVGs angewandt. Daher haben wir die Styles auf die darüberliegenden Elemente erweitert. Für das Search Icon war schon ein Parent-Element vorhanden. Für die Arrow Icons leider noch nicht, daher haben wir dafür ein 'span' mit 'arrow-icon' als Klasse genommen, welche jetzt alle eine Sichtbarkeit von 50 % haben. Darüber hinaus sind die CSS Änderungen auch rückwärts kompatibel.